### PR TITLE
Improve texts

### DIFF
--- a/app/components/Schedule/Schedule.latte
+++ b/app/components/Schedule/Schedule.latte
@@ -10,7 +10,7 @@
             </span>
             <div class="item-content disabled">
                 <span class="item-title">Vypsání přednášek</span>
-                Přednášky lze vypsat od 12.3.2018
+                Přednášky lze vypsat od 12. 3. 2018
                 <div>
                     <span class="btn btn-action btn-sm">Chci vypsat přednášku</span>
                 </div>
@@ -23,7 +23,7 @@
             </span>
             <div class="item-content disabled">
                 <span class="item-title">Hlasování o přednáškách</span>
-                Hlasování bude možné od 26.3.2018
+                Hlasování bude možné od 26. 3. 2018
                 <div>
                     <span class="btn btn-action btn-sm">Chci hlasovat</span>
                 </div>
@@ -36,7 +36,7 @@
             </span>
             <div class="item-content disabled">
                 <span class="item-title">Zveřejnění programu</span>
-                Jaký bude program bude jasné od 9.4.2018
+                Jaký bude program, bude jasné od 9. 4. 2018
                 <div>
                     <a href="#" class="btn btn-action btn-sm">Chci kouknout na program</a>
                 </div>
@@ -48,10 +48,10 @@
                 04
             </span>
             <div class="item-content">
-                <span class="item-title">!! BARCAMP !!</span>
-                21.4.2018 9:00 bude Barcamp!
+                <span class="item-title">Barcamp</span>
+                Barcamp bude 21. 4. 2018 od 9 hodin
                 <div>
-                    <span class="btn btn-action btn-sm disabled">Zobrazit harmonogram přednášek</span>
+                    <span class="btn btn-action btn-sm disabled">Jak se tam dostanu?</span>
                 </div>
             </div>
             <div class="progress" style="width: 0;height: 0"></div>
@@ -62,7 +62,7 @@
             </span>
             <div class="item-content">
                 <span class="item-title">Záznamy z přednášek</span>
-                Záznamy z přednášek zveřejníme 7. 5.2018
+                Záznamy z přednášek zveřejníme do 7. 5. 2018
                 <div>
                     <span class="btn btn-action btn-sm disabled">Kouknout na záznamy</span>
                 </div>


### PR DESCRIPTION
Trochu jsem vylepšil textaci v scheduleru.

- Datumy s mezerou (`12. 3. 2018` namísto `12.3.2018`),
- !! NAVRHUJI NEPOUŽÍVAT KAPITÁLKY S VYKŘIČNÍKY !!

Prosím @Dosty85 o review, přopadně merge.