### PR TITLE
Subordinate CSV export to broken Microsoft format

### DIFF
--- a/app/AdminModule/presenters/ConferencePresenter.php
+++ b/app/AdminModule/presenters/ConferencePresenter.php
@@ -57,8 +57,10 @@ class ConferencePresenter extends BasePresenter
      * @throws \Nette\Application\AbortException
      * @secured
      */
-    public function handleExportConfereeCsv()
+    public function handleExportConfereeCsv($msExcel = false)
     {
+        $delimiter = $msExcel ? ';' : ',';
+
         $allConferee = $this->confereeManager->findAll();
 
         ob_start();
@@ -66,7 +68,7 @@ class ConferencePresenter extends BasePresenter
         fputcsv(
             $df,
             ["Jméno", "E-mail", "Registrace", "Newsletter", "Souhlas získán", "Bio", "Firma", "Adresa"],
-            ";",
+            $delimiter,
             '"'
         );
 
@@ -86,13 +88,15 @@ class ConferencePresenter extends BasePresenter
                 $conferee->bio,
                 isset($extended['company']) ? $extended['company'] : null,
                 isset($extended['address']) ? $extended['address'] : null,
-            ], ";", '"');
+            ], $delimiter, '"');
         }
 
         fclose($df);
         $csv = ob_get_clean();
 
-        $csv = iconv("UTF-8", "WINDOWS-1250", $csv);
+        if ($msExcel) {
+            $csv = iconv("UTF-8", "WINDOWS-1250", $csv);
+        }
 
         $fileDatePostfix = gmdate("Ymd.his");
         header("Cache-Control: max-age=0, no-cache, must-revalidate, proxy-revalidate");
@@ -372,7 +376,7 @@ class ConferencePresenter extends BasePresenter
 
         $form->addHidden('id');
 
-        $form->addSelect('type', 'Type', [null=>'== Vyberte =='] + $this->getMergedTalks())
+        $form->addSelect('type', 'Type', [null => '== Vyberte =='] + $this->getMergedTalks())
             ->setRequired(true);
         $form->addRadioList('room', 'Místnost', $this->talkManager->getRooms())->setRequired(true);
         $form->addText('time', 'Čas konání')->setType('time')->setRequired(true);

--- a/app/AdminModule/presenters/ConferencePresenter.php
+++ b/app/AdminModule/presenters/ConferencePresenter.php
@@ -66,7 +66,7 @@ class ConferencePresenter extends BasePresenter
         fputcsv(
             $df,
             ["Jméno", "E-mail", "Registrace", "Newsletter", "Souhlas získán", "Bio", "Firma", "Adresa"],
-            ",",
+            ";",
             '"'
         );
 
@@ -86,11 +86,13 @@ class ConferencePresenter extends BasePresenter
                 $conferee->bio,
                 isset($extended['company']) ? $extended['company'] : null,
                 isset($extended['address']) ? $extended['address'] : null,
-            ], ",", '"');
+            ], ";", '"');
         }
 
         fclose($df);
         $csv = ob_get_clean();
+
+        $csv = iconv("UTF-8", "WINDOWS-1250", $csv);
 
         $fileDatePostfix = gmdate("Ymd.his");
         header("Cache-Control: max-age=0, no-cache, must-revalidate, proxy-revalidate");

--- a/app/AdminModule/presenters/templates/Conference/conferee.latte
+++ b/app/AdminModule/presenters/templates/Conference/conferee.latte
@@ -3,10 +3,20 @@
 
 <div class="panel panel-default">
     <div class="panel-body">
-        <a href="{link exportConfereeCsv!}" class="pull-right btn btn-default">
-            <i class="glyphicon glyphicon-cloud-download"></i>
-            Stáhnout jako CSV
-        </a>
+        <div class="btn-group pull-right">
+            <a href="{link exportConfereeCsv!}" class="btn btn-default">
+                <i class="glyphicon glyphicon-cloud-download"></i> Stáhnout jako CSV
+            </a>
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="caret"></span>
+                <span class="sr-only">Další možnosti</span>
+            </button>
+            <ul class="dropdown-menu">
+                <li><a href="{link exportConfereeCsv!}">Klasické CSV</a></li>
+                <li><a href="{link exportConfereeCsv!, 'msExcel' => true}">Microsoft Excel CSV pro Windows</a></li>
+
+            </ul>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Opravu, přesněji řečeno _„opravu“_ jsem provedl, ale **opravdu se ji zdráhám nasadit** a vědomě si tím do projektu zavléct chybu. 

Microsoft Excel má import CSV implementovaný chybně, ví o tom, neřeší to a komplikuje to používání obecných výměnných formátů, jakým CSV je. Chápu snahu uživateli co nejvíce usnadnit práci s nástrojem, ale tím si na svoje bedra přenášíme odpovědnost za chybu někoho jiného. Podpora takového postupu jen prodlužuje životnost a _obhajitelnost_ takové chyby.

Nepřijde mi to korektní ani vůči nám jako dodavateli, tak ani vůči uživateli, který dostává produkt chybu (převod `UTF-8` → `WIN1250` je ztrátový, může data nevratně poškodit).

CSV jako takové je definované jako `comma-separated text`, tedy dělené čárkou, nikoliv středníkem (to samé popisuje i [RFC 4180](https://tools.ietf.org/html/rfc4180). Přinejmenším toto je tedy objektivní porušení standardu. Kódování 1250 snad není v tomto roce obhajitelné ničím…

**Navrhuji PR zamítnout a úpravu do kódu nezanášet.**